### PR TITLE
Make Legacy FAPI a dependency

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -44,5 +44,8 @@
   ],
   "custom": {
     "modmenu:clientsideOnly": true
+  },
+  "depends": {
+    "legacy-fabric-api": "*"
   }
 }


### PR DESCRIPTION
Then Modmenu won't launch without LFAPI, so dumb people like me don't forget.